### PR TITLE
feat: adds secret-provider-class

### DIFF
--- a/charts/secret-provider-class/Chart.yaml
+++ b/charts/secret-provider-class/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: secret-provider-class
+description: A Helm Chart to deploy SecretsProviderClass object
+
+type: application
+
+version: 0.1.0

--- a/charts/secret-provider-class/README.md
+++ b/charts/secret-provider-class/README.md
@@ -1,0 +1,16 @@
+# Secret Provider Class Helm Chart
+
+The following provides a method to create secrets needed by public HelmCharts in a GitOps-ish
+manner. The `secrets-provider` HelmChart will allow us to create a `SecretProviderClass`
+object containing all of the secret references we want to populate before deploying a public
+Helm Chart. This should prevent us from forking Helm Charts.
+
+Ideally, this chart can be deprecated once/if Flux CD is introduced to our ecosystem;
+the Kustomization operator will allow us to create ad-hoc objects of any type to
+extend the functionality of Helm Chart in a pure GitOps manner.
+
+## Installation
+
+```bash
+$ helm upgrade --install -f your-values-file.yaml secret-provider-class . --namespace target_namespace
+```

--- a/charts/secret-provider-class/templates/secretprovider.yml
+++ b/charts/secret-provider-class/templates/secretprovider.yml
@@ -1,0 +1,12 @@
+{{- if .Values.secretProvider.enabled -}}
+apiVersion: secrets-store.csi.x-k8s.io/v1
+kind: SecretProviderClass
+metadata:
+  name: {{ .Values.secretProvider.name }}
+spec:
+  provider: {{ .Values.secretProvider.provider }}
+  secretObjects:
+    {{- toYaml .Values.secretProvider.secretObjects | nindent 4 }}
+  parameters:
+    {{- toYaml .Values.secretProvider.parameters | nindent 4 }}
+{{- end }}

--- a/charts/secret-provider-class/values.yaml
+++ b/charts/secret-provider-class/values.yaml
@@ -1,0 +1,32 @@
+# Additional Information:
+# - https://secrets-store-csi-driver.sigs.k8s.io/concepts
+# - https://github.com/aws/secrets-store-csi-driver-provider-aws
+
+# Deploys a single `SecretProviderClass`
+# - A single SPC may be used to spawn one or many secrets
+# - A secret MUST be mounted by a `Pod` to be generated
+#   - This means you need to define the `Secret` in `volumes:` and `volumeMounts:`
+#   - In must respectable public HelmCharts there is a method to do so via `extraVolumes` and `extraVolumeMounts`, or similarly named.
+secretProvider:
+  enabled: false
+  provider: aws
+  name: name-of-the-SecretProviderClass
+#  secretObjects:
+#    - data:
+#      - key: user
+#        objectName: application_user
+#      - key: password
+#        objectName: application_password
+#      secretName: application-admin-credentials
+#      type: Opaque
+#  parameters:
+#    objects: |
+#      - objectName: "path/to/secretsmanager/secret"
+#        objectType: "secretsmanager"
+#        jmesPath:
+#            # If either the 'path' or the 'objectAlias' fields contain a hyphen, then they must be escaped with a single quote
+#            # path and objectAlias are required when using jmesPath
+#            - path: "user"
+#              objectAlias: "application_user"
+#            - path: "password"
+#              objectAlias: "application_password"


### PR DESCRIPTION
Adds a "base" Helm Chart named `secret-provider-class`. This chart may be leveraged to create secret objects before installing publicly available charts that have secret dependency; this removes the need to manually create secrets.