### PR TITLE
feat: centralize mappings

### DIFF
--- a/charts/mappings/Chart.yaml
+++ b/charts/mappings/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: mappings
+description: A Helm Chart to deploy Mapping objects
+
+type: application
+
+version: 0.1.0

--- a/charts/mappings/README.md
+++ b/charts/mappings/README.md
@@ -1,0 +1,15 @@
+# Mappings Helm Chart
+
+The following provides a method to create mappings needed by public HelmCharts in a GitOps-ish
+manner. The `mappings` HelmChart will allow us to create one or many `Mapping`
+objects, allowing us to actively use public charts that do not support the Mapping type.
+
+Ideally, this chart can be deprecated once/if Flux CD is introduced to our ecosystem;
+the Kustomization operator will allow us to create ad-hoc objects of any type to
+extend the functionality of Helm Chart in a pure GitOps manner.
+
+## Installation
+
+```bash
+$ helm upgrade --install -f your-values-file.yaml mappings . --namespace target_namespace
+```

--- a/charts/mappings/templates/mappings.yaml
+++ b/charts/mappings/templates/mappings.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.enabled -}}
+{{- $values := .Values -}}
+{{- range $mapping := .Values.mappings -}}
+---
+apiVersion: getambassador.io/v2
+kind: Mapping
+metadata:
+  name: {{ $mapping.host }}
+  namespace: {{ $values.target_namespace }}
+spec:
+  ambassador_id:
+  - {{ $values.ambassador_id }}
+  host: {{ $mapping.host }}{{ $values.domain_suffix }}
+  prefix: {{ $mapping.prefix }}
+  service: {{ $mapping.service }}
+{{ end }}
+{{- end }}

--- a/charts/mappings/values.yaml
+++ b/charts/mappings/values.yaml
@@ -1,0 +1,11 @@
+enabled: false
+domain_suffix: ""
+ambassador_id: "--apiVersion-v3alpha1-only--default"
+target_namespace: ""
+mappings: []
+#  - host: foo
+#    prefix: /
+#    service: foo
+#  - host: bar
+#    prefix: /
+#    service: bar


### PR DESCRIPTION
Adds the scaffolding to cenerate multiple YAML documents, providing custom acceptable values to the `Mapping` object.