### PR TITLE
Add `dependabot.yml` for version update config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "docker"
+    directory: "/charts"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
This PR adds the [`dependabot.yml`](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file) config file, which defines which package types dependabot should look for update for, and on what schedule.

This repo is a little unique in that it doesn't have app code it in. However, dependabot does [`docker`](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#docker) for its `package-ecosystem`, which is supposed to check Kubernetes and Helm configs, in addition to `Dockerfile`s. So...not sure if this is exactly right as-is. It might require some iteration. 🤷 

Also, unlike the other repos, I'm not going to create a corresponding CodeQL setup for this repo since there is not app code.