### PR TITLE
feat(frontend): add configmap

### DIFF
--- a/charts/frontend/templates/configmap.yaml
+++ b/charts/frontend/templates/configmap.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.configmap.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.configmap.name }}
+data:
+  {{- tpl (toYaml .Values.configmap.data) . | nindent 2 }}
+{{- end }}

--- a/charts/frontend/templates/deployment.yaml
+++ b/charts/frontend/templates/deployment.yaml
@@ -40,7 +40,7 @@ spec:
           env:
             {{- toYaml .Values.env | nindent 12 }}
           envFrom:
-            {{- toYaml .Values.envFrom | nindent 12 }}
+            {{- tpl (toYaml .Values.envFrom) . | nindent 12 }}
           ports:
             - name: http
               containerPort: {{ .Values.service.containerPort }}

--- a/charts/frontend/values.yaml
+++ b/charts/frontend/values.yaml
@@ -60,3 +60,10 @@ autoscaling:
   maxReplicas: 100
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
+
+envFrom: []
+
+configmap:
+  enabled: false
+  name: ""
+  data: {}


### PR DESCRIPTION
Let's use a configmap for the `sbl-frontend` repo, since we can [use env vars at runtime](https://github.com/cfpb/sbl-frontend/pull/428) now 🥳

Closes #14 

## Current behavior
- env vars need to be baked into images in order for `sbl-frontend` to work

## Expected behavior
- container env vars are defined by a configmap, templatized in the helm values.yaml, and then loaded at runtime by `import-meta-env`

## Additions

- same changes as previous PR #7 for user-fi, but also includes `envFrom`
- adds `configmap.yaml`
- eval template in `deployment.yaml`
- add configmap and `envFrom` to `values.yaml`

## Testing

1. Test in conjunction with the accompanying enterprise PR, see the testing instructions there

## TODOs
- [x] depends on [this SBL Frontend PR to be merged first](https://github.com/cfpb/sbl-frontend/pull/428)

