### PR TITLE
make a unique image build number that is also persistant

### DIFF
--- a/.github/workflows/build_and_publish_images.yml
+++ b/.github/workflows/build_and_publish_images.yml
@@ -27,28 +27,28 @@ jobs:
       - name: 'Build and Publish alpine image'
         run: |
           docker build -t ghcr.io/cfpb/regtech/sbl/alpine:v3.18.0 -f Dockerfile-alpine .
-          docker tag ghcr.io/cfpb/regtech/sbl/alpine:v3.18.0 ghcr.io/cfpb/regtech/sbl/alpine:v3.18.0_${{github.run_attempt}}
+          docker tag ghcr.io/cfpb/regtech/sbl/alpine:v3.18.0 ghcr.io/cfpb/regtech/sbl/alpine:v3.18.0_${{github.run_number}}.${{github.run_attempt}}
           docker tag ghcr.io/cfpb/regtech/sbl/alpine:v3.18.0 ghcr.io/cfpb/regtech/sbl/alpine:latest
           docker push ghcr.io/cfpb/regtech/sbl/alpine --all-tags
 
       - name: 'Build and Publish python-alpine image'
         run: |
           docker build -t ghcr.io/cfpb/regtech/sbl/python-alpine:v3.12.0 -f Dockerfile-python-alpine .
-          docker tag ghcr.io/cfpb/regtech/sbl/python-alpine:v3.12.0 ghcr.io/cfpb/regtech/sbl/python-alpine:v3.12.0_${{github.run_attempt}}
+          docker tag ghcr.io/cfpb/regtech/sbl/python-alpine:v3.12.0 ghcr.io/cfpb/regtech/sbl/python-alpine:v3.12.0_${{github.run_number}}.${{github.run_attempt}}
           docker tag ghcr.io/cfpb/regtech/sbl/python-alpine:v3.12.0 ghcr.io/cfpb/regtech/sbl/python-alpine:latest
           docker push ghcr.io/cfpb/regtech/sbl/python-alpine --all-tags
 
       - name: 'Build and Publish nginx-alpine image'
         run: |
           docker build -t ghcr.io/cfpb/regtech/sbl/nginx-alpine:v1.27.0 -f Dockerfile-nginx-alpine .
-          docker tag ghcr.io/cfpb/regtech/sbl/nginx-alpine:v1.27.0 ghcr.io/cfpb/regtech/sbl/nginx-alpine:v1.27.0_${{github.run_attempt}}
+          docker tag ghcr.io/cfpb/regtech/sbl/nginx-alpine:v1.27.0 ghcr.io/cfpb/regtech/sbl/nginx-alpine:v1.27.0_${{github.run_number}}.${{github.run_attempt}}
           docker tag ghcr.io/cfpb/regtech/sbl/nginx-alpine:v1.27.0 ghcr.io/cfpb/regtech/sbl/nginx-alpine:latest
           docker push ghcr.io/cfpb/regtech/sbl/nginx-alpine --all-tags
 
       - name: 'Build and Publish node-js-alpine image'
         run: |
           docker build -t ghcr.io/cfpb/regtech/sbl/node-js-alpine:v3.20.0 -f Dockerfile-node-js-alpine .
-          docker tag ghcr.io/cfpb/regtech/sbl/node-js-alpine:v3.20.0 ghcr.io/cfpb/regtech/sbl/node-js-alpine:v3.20.0_${{github.run_attempt}}
+          docker tag ghcr.io/cfpb/regtech/sbl/node-js-alpine:v3.20.0 ghcr.io/cfpb/regtech/sbl/node-js-alpine:v3.20.0_${{github.run_number}}.${{github.run_attempt}}
           docker tag ghcr.io/cfpb/regtech/sbl/node-js-alpine:v3.20.0 ghcr.io/cfpb/regtech/sbl/node-js-alpine:latest
           #docker push ghcr.io/cfpb/regtech/sbl/node-js-alpine --all-tags
           #do not push until Package Settings have been updated to allow GHA from this repo
@@ -56,6 +56,6 @@ jobs:
       - name: 'Build and Publish python-ubi8 image'
         run: |
           docker build -t ghcr.io/cfpb/regtech/sbl/python-ubi8:v3.12.0 -f Dockerfile-python-ubi8 .
-          docker tag ghcr.io/cfpb/regtech/sbl/python-ubi8:v3.12.0 ghcr.io/cfpb/regtech/sbl/python-ubi8:v3.12.0_${{github.run_attempt}}
+          docker tag ghcr.io/cfpb/regtech/sbl/python-ubi8:v3.12.0 ghcr.io/cfpb/regtech/sbl/python-ubi8:v3.12.0_${{github.run_number}}.${{github.run_attempt}}
           docker tag ghcr.io/cfpb/regtech/sbl/python-ubi8:v3.12.0 ghcr.io/cfpb/regtech/sbl/python-ubi8:latest
           docker push ghcr.io/cfpb/regtech/sbl/python-ubi8 --all-tags


### PR DESCRIPTION
use github.run_number combined with github.run_attempt to get a persistent and unique build tag