### PR TITLE
feat: allow manual trigger for build and publish images

### DIFF
--- a/.github/workflows/build_and_publish_images.yml
+++ b/.github/workflows/build_and_publish_images.yml
@@ -6,6 +6,7 @@ on:
       - main
   schedule:
     - cron: "0 5 * * Sun"
+  workflow_dispatch:
 
 jobs:
   build-publish-image:


### PR DESCRIPTION
Allow for manually triggering the base image build and publish, so we can do on demand builds in case security updated base images are published between the weekly scheduled builds. Documentation for allowing manual triggers: https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/manually-running-a-workflow